### PR TITLE
Allow : in command parameters

### DIFF
--- a/Classes/OptimizeImageService.php
+++ b/Classes/OptimizeImageService.php
@@ -43,7 +43,7 @@ class OptimizeImageService {
 		}
 
 		$parameters = $this->configuration[$extension . 'ParametersOn' . $when];
-		$parameters = preg_replace('/[^A-Za-z0-9-% =]/', "", $parameters);
+		$parameters = preg_replace('/[^A-Za-z0-9-%: =]/', "", $parameters);
 		$parameters = preg_replace('/%s/', $file, $parameters);
 
 		$command = $binary . ' ' . $parameters . ' 2>&1';


### PR DESCRIPTION
By allowing : in command parameters we can use convert to handle images (convert puzzle.jpg -sampling-factor 4:2:0 -strip -quality 85 -interlace JPEG -colorspace RGB puzzle_converted.jpg). See https://developers.google.com/speed/docs/insights/OptimizeImages