### PR TITLE
Add jpegoptim to installation command

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Lossless image optimization. Process jpg/png/gif/svg images with binaries and pa
 
 ## Installation
 
-Debian/Ubuntu: `apt-get install optipng libjpeg-turbo-progs gifsicle`
+Debian/Ubuntu: `apt-get install optipng jpegoptim libjpeg-turbo-progs gifsicle`
 
 svgo is installable via NPM `npm install -g svgo`
 


### PR DESCRIPTION
I'm trying to run your extension and installed the packages on my Debian server with the command from your readme file. But "jpegoptim" was missing and I had to install it separately. So I added it to your install command.