### PR TITLE
Bugfix: Do not process original files

### DIFF
--- a/Classes/FileAspects.php
+++ b/Classes/FileAspects.php
@@ -51,7 +51,7 @@ class FileAspects
      */
     public function processFile($fileProcessingService, $driver, $processedFile)
     {
-        if ($processedFile->isUpdated() === true) {
+        if ($processedFile->isUpdated() === true && !$processedFile->usesOriginalFile()) {
             // ToDo: Find better possibility for getPublicUrl()
             $this->service->process(PATH_site . $processedFile->getPublicUrl(), $processedFile->getExtension());
         }


### PR DESCRIPTION
Processed files which are using the original file must not be optimized.

The original file is already optimized if the user has choosen to optimize files directly on upload. Otherwise the original file should never be touched.