### PR TITLE
Task: check if file exists to avoid warning

### DIFF
--- a/Classes/OptimizeImageService.php
+++ b/Classes/OptimizeImageService.php
@@ -51,6 +51,10 @@ class OptimizeImageService implements LoggerAwareInterface
     {
         $this->reset();
 
+        if (!\file_exists($file)) {
+            return;
+        }
+        
         if ($extension === null) {
             $pathinfo = pathinfo($file);
             if ($pathinfo['extension'] !== null) {


### PR DESCRIPTION
Check if file exists, cause if a picture is deleted from file system but assigned to an content element the process method get triggered and throws a php warning because the picture is not found.