### PR TITLE
Add the extension key to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,11 @@
       "Lemming\\Imageoptimizer\\": "Classes/"
     }
   },
+  "extra": {
+    "typo3/cms": {
+      "extension-key":"imageoptimizer"
+    }
+  },
   "replace": {
     "christophlehmann/imageoptimizer": "self.version",
     "typo3-ter/imageoptimizer": "self.version"


### PR DESCRIPTION
Not defining the extension key now triggers a warning and will be a hard
error in future TYPO3 versions.